### PR TITLE
helm: update upstream url of k8s helm

### DIFF
--- a/helm.sh
+++ b/helm.sh
@@ -42,7 +42,7 @@ helm init --client-only >/dev/null
 # Remove local repo to increase reproducibility and remove errors
 helm repo list |grep -qc local && $BINARY repo remove local >/dev/null
 
-helm plugin list | grep -qc tiller || $BINARY plugin install $(dirname $(rlocation __main__/external/helm_tiller/WORKSPACE))
+helm plugin list | grep -qc tiller || $BINARY plugin install $(dirname $(rlocation helm_tiller/WORKSPACE))
 
 cd "${BUILD_WORKING_DIRECTORY:-}"
 helm $*

--- a/helm.sh
+++ b/helm.sh
@@ -38,7 +38,7 @@ fi
 export HELM_HOME="$(pwd)/.helm"
 export PATH="$(dirname $BINARY):$PATH"
 #export HELM_TILLER_SILENT=true
-helm init --client-only >/dev/null
+# helm init --client-only >/dev/null
 # Remove local repo to increase reproducibility and remove errors
 helm repo list |grep -qc local && $BINARY repo remove local >/dev/null
 

--- a/repos.bzl
+++ b/repos.bzl
@@ -12,15 +12,15 @@ def helm_repositories():
 
     http_archive(
         name = "helm",
-        sha256 = "538f85b4b73ac6160b30fd0ab4b510441aa3fa326593466e8bf7084a9c288420",
-        urls = ["https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz"],
+        sha256 = "07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262",
+        urls = ["https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz"],
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
     )
 
     http_archive(
         name = "helm_osx",
-        sha256 = "71d213d63e1b727d6640c4420aee769316f0a93168b96073d166edcd3a425b3d",
-        urls = ["https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz"],
+        sha256 = "84a1ff17dd03340652d96e8be5172a921c97825fd278a2113c8233a4e8db5236",
+        urls = ["https://get.helm.sh/helm-v3.6.3-darwin-amd64.tar.gz"],
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
     )
 

--- a/repos.bzl
+++ b/repos.bzl
@@ -12,22 +12,22 @@ def helm_repositories():
 
     http_archive(
         name = "helm",
-        sha256 = "804f745e6884435ef1343f4de8940f9db64f935cd9a55ad3d9153d064b7f5896",
-        urls = ["https://storage.googleapis.com/kubernetes-helm/helm-v2.14.1-linux-amd64.tar.gz"],
+        sha256 = "538f85b4b73ac6160b30fd0ab4b510441aa3fa326593466e8bf7084a9c288420",
+        urls = ["https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz"],
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
     )
 
     http_archive(
         name = "helm_osx",
-        sha256 = "392ec847ecc5870a48a39cb0b8d13c8aa72aaf4365e0315c4d7a2553019a451c",
-        urls = ["https://storage.googleapis.com/kubernetes-helm/helm-v2.14.1-darwin-amd64.tar.gz"],
+        sha256 = "71d213d63e1b727d6640c4420aee769316f0a93168b96073d166edcd3a425b3d",
+        urls = ["https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz"],
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
     )
 
     new_git_repository(
         name = "helm_tiller",
         remote = "https://github.com/rimusz/helm-tiller",
-        commit = "a77f505e062d8337e8fd638796bfecc8a4a00bcc",
-        shallow_since = "1553679518 +0000",
+        commit = "0305b56f535b7dc3c8e9aa640a7a4732c9200e42",
+        shallow_since = "1573742255 +0000",
         build_file = "@com_github_tmc_rules_helm//:helm.BUILD",
     )


### PR DESCRIPTION
this bucket is long-gone, move to a URL that is still valid.

currently, if somebody runs this from a context without caching, this
will fail to download/download an invalid payload, and fail shasum
validation, leading to the consuming tool not functioning.
